### PR TITLE
Change to the new artifactory domain

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
 		<repository>
 			<id>camunda-bpm-nexus</id>
 			<name>camunda-bpm-nexus</name>
-			<url>https://app.camunda.com/nexus/content/groups/public</url>
+			<url>https://artifacts.camunda.com/artifactory/public/</url>
 		</repository>
 	</repositories>
 
@@ -200,12 +200,12 @@
 		<repository>
 			<id>camunda-nexus</id>
 			<name>camunda bpm community extensions</name>
-			<url>https://app.camunda.com/nexus/content/repositories/camunda-bpm-community-extensions</url>
+			<url>https://artifacts.camunda.com/artifactory/camunda-bpm-community-extensions/</url>
 		</repository>
 		<snapshotRepository>
 			<id>camunda-nexus</id>
 			<name>camunda bpm community extensions snapshots</name>
-			<url>https://app.camunda.com/nexus/content/repositories/camunda-bpm-community-extensions-snapshots</url>
+			<url>https://artifacts.camunda.com/artifactory/camunda-bpm-community-extensions-snapshots/</url>
 			<!-- for maven 2 compatibility -->
 			<uniqueVersion>true</uniqueVersion>
 		</snapshotRepository>


### PR DESCRIPTION
We created a new domain name for our repository manager (Artifactory) to replace the old Nexus proxy URL (app.camunda.com/nexus). The proxy URL will be removed in the future. 

Related to INFRA-3114



